### PR TITLE
Fix build error for rustc 1.40.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ where
         .enumerate()
         .for_each(|(i, byte)| sig[i] = *byte);
 
-    let signature = Multisig::from_ed25519(sig);
+    let signature = Multisig::from_ed25519(&sig);
 
     new_message.signature = Some(signature);
 


### PR DESCRIPTION
error[E0308]: mismatched types
   --> /home/user/.cargo/git/checkouts/ssb-publish-10301cd71dcae7b4/d8b9068/src/lib.rs:162:44
    |
162 |     let signature = Multisig::from_ed25519(sig);
    |                                            ^^^
    |                                            |
    |                                            expected &[u8; 64], found array of 64 elements
    |                                            help: consider borrowing here: `&sig`
    |
    = note: expected type `&[u8; 64]`
               found type `[u8; 64]`